### PR TITLE
Improve mission cleanup

### DIFF
--- a/HRM_Mission.cpp
+++ b/HRM_Mission.cpp
@@ -26,7 +26,15 @@ HRM_Mission::HRM_Mission() :
 
 HRM_Mission::~HRM_Mission()
 {
-	//for (auto p_obj : m_object_vector) delete p_obj;
+        for (auto p_obj : m_object_vector)
+        {
+                if (p_obj != NULL)
+                {
+                        p_obj->DestroyInstance();
+                        delete p_obj;
+                }
+        }
+        m_object_vector.clear();
 }
 
 void HRM_Mission::SetPosition(double zero_latitude, double zero_longitude, double zero_heading)

--- a/HRM_PlugIn.cpp
+++ b/HRM_PlugIn.cpp
@@ -204,25 +204,41 @@ void HRM_PlugIn::PluginStart()
 
 
 
+
 void HRM_PlugIn::PluginStop()
 {
 
-	
-	if (m_initialized == false) return;
+    if (m_initialized == false) return;
 
-	
+    XPLMUnregisterFlightLoopCallback(WrapFlightLoopCallback, 0);
 
-	XPLMUnregisterFlightLoopCallback(WrapFlightLoopCallback, 0);
+    XPLMDestroyMenu(m_PluginMenuID);
 
-	XPLMDestroyMenu(m_PluginMenuID);
+    SaveConfig();
 
-	SaveConfig();
+    // Remove any remaining mission objects and free memory
+    MissionReset();
 
+    auto delete_missions = [](std::vector<HRM_Mission*> &vec)
+    {
+        for (auto p_mission : vec)
+        {
+            if (p_mission)
+                delete p_mission;
+        }
+        vec.clear();
+    };
 
-	
+    delete_missions(m_street_missions);
+    delete_missions(m_urban_missions);
+    delete_missions(m_sar_missions);
+    delete_missions(m_sling_missions);
+    delete_missions(m_street_fire_missions);
+    delete_missions(m_urban_fire_missions);
+    delete_missions(m_sar_fire_missions);
+    delete_missions(m_sling_fire_missions);
 
 }
-
 void HRM_PlugIn::PluginEnable()
 {
 	m_plugin_enabled = 1;


### PR DESCRIPTION
## Summary
- destroy and delete mission objects in `HRM_Mission` destructor
- clean up missions and clear containers when the plugin stops

## Testing
- `make` *(fails: XPLMUtilities.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68877520d6b883339f1de9b92123d0b5