### PR TITLE
Fix probe cleanup in HRM_Object destructor

### DIFF
--- a/HRM_Object.cpp
+++ b/HRM_Object.cpp
@@ -314,6 +314,9 @@ HRM_Object::HRM_Object()
 
 HRM_Object::~HRM_Object()
 {
-	HRMDebugString("Destroying Probe");
-	if (!m_probe) XPLMDestroyProbe(m_probe);
+        HRMDebugString("Destroying Probe");
+        if (m_probe) {
+                XPLMDestroyProbe(m_probe);
+                m_probe = nullptr;
+        }
 }


### PR DESCRIPTION
## Summary
- ensure `XPLMDestroyProbe` only runs when probe exists
- null out the probe handle after destruction

## Testing
- `make` *(fails: `XPLMUtilities.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68877507c6288333bf54a511b7bf8e51